### PR TITLE
Replace string literal to ::class keyword

### DIFF
--- a/Block/Adminhtml/System/Config/DirectLink.php
+++ b/Block/Adminhtml/System/Config/DirectLink.php
@@ -98,7 +98,7 @@ class DirectLink extends Field
     public function getButtonHtml()
     {
         $button = $this->getLayout()->createBlock(
-            'Magento\Backend\Block\Widget\Button'
+            \Magento\Backend\Block\Widget\Button::class
         )->setData(
             [
                 'id' => 'swell_direct_login_link_button',

--- a/Console/Command/RemoveOldSyncRecordsCommand.php
+++ b/Console/Command/RemoveOldSyncRecordsCommand.php
@@ -66,7 +66,7 @@ class RemoveOldSyncRecordsCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->_jobs = $this->_objectManager->get('\Yotpo\Loyalty\Cron\Jobs');
+        $this->_jobs = $this->_objectManager->get(\Yotpo\Loyalty\Cron\Jobs::class);
 
         try {
             $output->writeln('<info>' . 'Working on it (Imagine a spinning gif loager) ...' . '</info>');

--- a/Console/Command/SyncCommand.php
+++ b/Console/Command/SyncCommand.php
@@ -72,7 +72,7 @@ class SyncCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->_jobs = $this->_objectManager->get('\Yotpo\Loyalty\Cron\Jobs');
+        $this->_jobs = $this->_objectManager->get(\Yotpo\Loyalty\Cron\Jobs::class);
 
         try {
             $output->writeln('<info>' . 'Working on it (Imagine a spinning gif loager) ...' . '</info>');

--- a/Console/Command/UninstallCommand.php
+++ b/Console/Command/UninstallCommand.php
@@ -65,8 +65,8 @@ class UninstallCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->_resourceConnection = $this->_objectManager->get('\Magento\Framework\App\ResourceConnection');
-        $this->_eavSetupFactory = $this->_objectManager->get('\Magento\Eav\Setup\EavSetupFactory');
+        $this->_resourceConnection = $this->_objectManager->get(\Magento\Framework\App\ResourceConnection::class);
+        $this->_eavSetupFactory = $this->_objectManager->get(\Magento\Eav\Setup\EavSetupFactory::class);
 
         if (!$this->confirmQuestion(self::CONFIRM_MESSAGE, $input, $output)) {
             return;

--- a/Model/Api/Swell/Index/CreateCouponManagement.php
+++ b/Model/Api/Swell/Index/CreateCouponManagement.php
@@ -164,13 +164,13 @@ class CreateCouponManagement extends AbstractSwell implements \Yotpo\Loyalty\Api
                     if (count($appliesToAttributes) > 0) {
                         $conditions = $actions = [];
                         $conditions["1"] = $actions["1"] = [
-                            "type" => "Magento\SalesRule\Model\Rule\Condition\Combine",
+                            "type" => \Magento\SalesRule\Model\Rule\Condition\Combine::class,
                             "aggregator" => $appliesToAnyOrAllAttributes,
                             "value" => 1,
                             "new_child" => ""
                         ];
                         $conditions["1--1"] = [
-                            "type" => "Magento\SalesRule\Model\Rule\Condition\Product\Found",
+                            "type" => \Magento\SalesRule\Model\Rule\Condition\Product\Found::class,
                             "aggregator" => $appliesToAnyOrAllAttributes,
                             "value" => 1,
                             "new_child" => ""
@@ -178,13 +178,13 @@ class CreateCouponManagement extends AbstractSwell implements \Yotpo\Loyalty\Api
                         foreach ($appliesToAttributes as $index => $appliesToAttribute) {
                             $appliesToValue = $appliesToValues[$index];
                             $conditions["1--1--" . ($index+1)] = [
-                                "type" => "Magento\SalesRule\Model\Rule\Condition\Product",
+                                "type" => \Magento\SalesRule\Model\Rule\Condition\Product::class,
                                 "attribute" => $appliesToAttribute,
                                 "operator" => "==",
                                 "value" => $appliesToValue
                             ];
                             $actions["1--" . ($index+1)] = [
-                                "type" => "Magento\SalesRule\Model\Rule\Condition\Product",
+                                "type" => \Magento\SalesRule\Model\Rule\Condition\Product::class,
                                 "attribute" => $appliesToAttribute,
                                 "operator" => "==",
                                 "value" => $appliesToValue

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -12,7 +12,7 @@ class Queue extends \Magento\Framework\Model\AbstractModel implements \Magento\F
 
     protected function _construct()
     {
-        $this->_init('Yotpo\Loyalty\Model\ResourceModel\Queue');
+        $this->_init(\Yotpo\Loyalty\Model\ResourceModel\Queue::class);
     }
 
     public function getIdentities()

--- a/Model/ResourceModel/Queue/Collection.php
+++ b/Model/ResourceModel/Queue/Collection.php
@@ -15,6 +15,9 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      */
     protected function _construct()
     {
-        $this->_init('Yotpo\Loyalty\Model\Queue', 'Yotpo\Loyalty\Model\ResourceModel\Queue');
+        $this->_init(
+            \Yotpo\Loyalty\Model\Queue::class, 
+            \Yotpo\Loyalty\Model\ResourceModel\Queue::class
+        );
     }
 }


### PR DESCRIPTION
According Magento guidelines https://devdocs.magento.com/guides/v2.2/coding-standards/code-standard-php.html#literal-namespace-rule string literals should be replaced to ::class and it`s checked as right solution in Magento PHPCS from 2.2, but It works on previous versions too.