### PR TITLE
Back up Yotpo_Core in dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "AFL-3.0"
     ],
     "require": {
-        "php": ">=5.6",
-        "magento/framework": ">=100.1.0"
+        "magento/framework": ">=100.1.0",
+        "yotpo/magento2-module-yotpo-core": "*"
     },
     "autoload": {
         "files": [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
 	<system>
-		<tab id="yotpo" translate="label" sortOrder="400">
-            <label><![CDATA[<span class='yotpo-icon'></span>Yotpo]]></label>
-		</tab>
 		<section id="yotpo_loyalty" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" canRestore="1">
 			<label>Loyalty &amp; Referrals</label>
 			<tab>yotpo</tab>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,6 +3,7 @@
 	<module name="Yotpo_Loyalty" setup_version="1.1.5">
         <sequence>
 			<module name="Magento_Catalog" />
+			<module name="Yotpo_Core" />
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
PR contains 2 things:
1. Removed php from requirements - Magento framework should be control that and it controls
2. Back up Yotpo_Core. Is was added in 1.0.3 and removed 1.1.0, but styling for Tab wasn`t reverted.
I suggest to restore that by adding Core module and it makes possible to make the same part for that module and Yotpo_Reviews. In addition You can move to core the same file Yotpo\Loyalty\Lib\Http\Client\Curl.   