### PR TITLE
fix(SnipperManagement.php):adding customer data tag as string inside an array

### DIFF
--- a/Model/Api/Swell/Session/SnippetManagement.php
+++ b/Model/Api/Swell/Session/SnippetManagement.php
@@ -164,7 +164,7 @@ class SnippetManagement implements \Yotpo\Loyalty\Api\Swell\Session\SnippetManag
                             data-id="' . $identificationData->getId() . '"
                         ';
                         if (($groupCode = $identificationData->getGroupCode())) {
-                            $response["snippet"] .= 'data-tags="[' . $groupCode . ']"';
+                            $response["snippet"] .= 'data-tags="[&#34;' . $groupCode . '&#34;]"';
                         }
                     }
                     $response["snippet"] .= '

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "yotpo/magento2-module-yotpo-loyalty",
     "description": "Magento 2 module for integration with Yotpo",
     "type": "magento2-module",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "repositories": [{
         "type": "git",
         "url": "https://github.com/YotpoLtd/magento2-module-yotpo-loyalty"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Yotpo_Loyalty" setup_version="1.1.8">
+	<module name="Yotpo_Loyalty" setup_version="1.1.9">
         <sequence>
 			<module name="Magento_Catalog" />
         </sequence>


### PR DESCRIPTION
Data tags should be an array of strings represented as a JSON string:
![image](https://user-images.githubusercontent.com/51117952/95058229-e696c600-06ff-11eb-8593-79bd17bc0e5f.png)

The current value will be: '[Active]' (where Active is a tag), instead of '["Active"]' which causes an error when reading it. This fix will make change it to be '["Active"]'