### PR TITLE
v1.2.4: Multistore support for swell_instance_id + CustomerSaveBefore - fix

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -393,12 +393,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $return = [];
         $swellApiKey = ($swellApiKey === null) ? $this->getRequest()->getParam("shared_secret") : (string)$swellApiKey;
-        foreach ($this->getStoreManager()->getWebsites($withDefault) as $website) {
-            if ($swellApiKey === $this->getSwellApiKey(\Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE, $website->getId())) {
-                $return[] = $website->getId();
+        $stores = $this->getStoreManager()->getStores($withDefault);
+        foreach ($stores as $key => $store) {
+            if ($this->isEnabled(\Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getId()) && $swellApiKey === $this->getSwellApiKey(\Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getId())) {
+                $return["_" . $store->getWebsiteId()] = $store->getWebsiteId();
             }
         }
-        return $return;
+        return array_values($return);
     }
 
     public function getMagentoVersion()

--- a/Model/Api/Swell/Session/SnippetManagement.php
+++ b/Model/Api/Swell/Session/SnippetManagement.php
@@ -57,6 +57,11 @@ class SnippetManagement implements \Yotpo\Loyalty\Api\Swell\Session\SnippetManag
         return $this->_yotpoHelper->getSwellGuid();
     }
 
+    public function getSwellApiKey()
+    {
+        return $this->_yotpoHelper->getSwellApiKey();
+    }
+
     protected function isCustomerLoggedIn()
     {
         return $this->_customerSession->isLoggedIn();
@@ -152,7 +157,7 @@ class SnippetManagement implements \Yotpo\Loyalty\Api\Swell\Session\SnippetManag
                         <!--/ Yotpo Loyalty - Reload customerData cart -->
                     ';
                 }
-                if (($swellGuid = $this->getSwellGuid())) {
+                if (($swellGuid = $this->getSwellGuid()) && ($swellApiKey = $this->getSwellApiKey())) {
                     $response["snippet"] .= '
                         <!-- Yotpo Loyalty - Swell JS Snippet -->
                         <div id="swell-customer-identification" style="display:none !important;"
@@ -162,6 +167,7 @@ class SnippetManagement implements \Yotpo\Loyalty\Api\Swell\Session\SnippetManag
                             data-authenticated="true"
                             data-email="' . $identificationData->getEmail() . '"
                             data-id="' . $identificationData->getId() . '"
+                            data-token="' . hash('sha256', $identificationData->getEmail() . $swellApiKey) . '"
                         ';
                         if (($groupCode = $identificationData->getGroupCode())) {
                             $response["snippet"] .= 'data-tags="[&#34;' . $groupCode . '&#34;]"';

--- a/Observer/CustomerSaveBefore.php
+++ b/Observer/CustomerSaveBefore.php
@@ -40,7 +40,7 @@ class CustomerSaveBefore implements ObserverInterface
                     if ($customer->isObjectNew()) {
                         $this->_registry->register('swell/customer/created', true);
                     } else {
-                        $customerId = $order->getId();
+                        $customerId = $customer->getId();
                         $this->_registry->register('swell/customer/original/email/id' . $customerId, $customer->getOrigData("email"));
                         $this->_registry->register('swell/customer/original/group_id/id' . $customerId, $customer->getOrigData("group_id"));
                     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "yotpo/magento2-module-yotpo-loyalty",
     "description": "Magento 2 module for integration with Yotpo",
     "type": "magento2-module",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "repositories": [{
         "type": "git",
         "url": "https://github.com/YotpoLtd/magento2-module-yotpo-loyalty"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -30,7 +30,7 @@
 					<backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
 			</group>
-			<group id="sync_settings" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="10" translate="label">
+			<group id="sync_settings" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="20" translate="label">
 				<label>Sync Settings (Advanced)</label>
 				<field id="swell_sync_limit" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Sync Limit</label>
@@ -46,9 +46,9 @@
 				   <comment>For how long should we keep old sent/failed items on the database (`yotpo_sync_queue`)?</comment>
 				</field>
 			</group>
-			<group id="advanced" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="20" translate="label">
+			<group id="advanced" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="30" translate="label">
 				<label>Advanced</label>
-				<field id="swell_instance_id" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+				<field id="swell_instance_id" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
 					<label>Checkout Variable Instance Id</label>
 					<comment>Your checkout module instance id</comment>
 				</field>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Yotpo_Loyalty" setup_version="1.2.3">
+	<module name="Yotpo_Loyalty" setup_version="1.2.4">
         <sequence>
 			<module name="Magento_Catalog" />
         </sequence>


### PR DESCRIPTION
* Added swell_instance_id to the website and store config scopes.
* Fix error on CustomerSaveBefore Observer
* Added customer token to js snippet.
* Improved getWebsiteIdsBySwellApiKey() in order to fix possible issues when the website has no value.