### PR TITLE
API url generation for the snippet moved to block

### DIFF
--- a/Block/Snippet.php
+++ b/Block/Snippet.php
@@ -4,4 +4,25 @@ namespace Yotpo\Loyalty\Block;
 
 class Snippet extends \Yotpo\Loyalty\Block\AbstractBlock
 {
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    public $storeManager;
+
+    public function __construct(
+        \Magento\Framework\View\Element\Template\Context $context,
+        \Yotpo\Loyalty\Helper\Data $yotpoHelper,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+    ) {
+        parent::__construct($context, $yotpoHelper);
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSwellSessionSnippetApiUrl()
+    {
+        return $this->storeManager->getStore()->getUrl('rest/V1/swell/session/snippet');
+    }
 }

--- a/view/frontend/templates/snippet.phtml
+++ b/view/frontend/templates/snippet.phtml
@@ -16,8 +16,7 @@
         ],function($, storage, url) {
             $(document).ready(function() {
                 try {
-                    storage.get(
-                        url.build('rest/V1/swell/session/snippet')
+                    storage.get( <?= $block->getSwellSessionSnippetApiUrl() ?>
                     ).done(function (response) {
                         response = JSON.parse(response);
                         if(!response.error && response.snippet){


### PR DESCRIPTION
API URL generation for the snippet endpoint 'rest/V1/swell/session/snippet' moved to block