### PR TITLE
fix (postDeleteCoupon): LR-5308 Merchant receives 503 on checkout variable slider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "yotpo/magento2-module-yotpo-loyalty",
     "description": "Magento 2 module for integration with Yotpo",
     "type": "magento2-module",
-    "version": "1.2.8",
+    "version": "1.2.9",
     "repositories": [{
         "type": "git",
         "url": "https://github.com/YotpoLtd/magento2-module-yotpo-loyalty"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Yotpo_Loyalty" setup_version="1.2.8">
+    <module name="Yotpo_Loyalty" setup_version="1.2.9">
         <sequence>
 			<module name="Magento_Catalog" />
         </sequence>


### PR DESCRIPTION
In postDeleteCoupon clean coupons from the quote.

The problem occurs when the Amasty_Affiliate module is also installed.

When a quote is loaded in the Yotpo_Loyalty module, then recollect occurs automatically, this is how Magento works. When recollecting, Magеnto checks for active coupons and removes them from the quote if coupons have been removed and also recalculates the price. Since there was a conflict between the Amasty_Affiliate and Yotpo_Loyalty modules, Magento was unable to recollect the quote and trigger_recollect remained equal to 1 permanently. Because of this, we see an error.

The fix makes it possible to remove the old coupon and recollect the quote until it is loaded the next time the points are added, until the plugin is called from the Amasty_Affiliate module. Therefore, the quote is recollected and trigger_recollect becomes equal to zero first, in the /V1/swell/index/delete_coupon api call, and only after that the /V1/swell/index/delete_coupon api endpoint is called where the quote no longer has problems with the old rule and coupon.

The solution to the problem is by making a quote recollect earlier, in the Yotpo_Loyalty module.