### PR TITLE
Add check that item exists before calling member function

### DIFF
--- a/Plugin/Checkout/Model/Cart.php
+++ b/Plugin/Checkout/Model/Cart.php
@@ -13,6 +13,10 @@ class Cart
     {
         foreach ($data as $itemId => &$itemInfo) {
             $item = $subject->getQuote()->getItemById($itemId);
+            if (!$item) {
+                continue;
+            }
+
             if ($item->getSwellAddedItem() && !($item->getCustomPrice()*1) && (isset($itemInfo['qty']) && $itemInfo['qty'] > 1)) {
                 $itemInfo['qty'] = 1;
             }


### PR DESCRIPTION
Very occasionally we see this error on our production site:

```
 report.CRITICAL: Error: Call to a member function getSwellAddedItem() on bool in /app/{redacted}/vendor/yotpo/magento2-module-yotpo-loyalty/Plugin/Checkout/Model/Cart.php:16
```

(By occasionally I mean the error occurs approximately once or twice per week, on a site doing several thousand orders a week).

This check simply ensures that the item exists before attempting to call `getSwellAddedItem()` on it.

I don't understand why `$item` is sometimes false, however it is worth noting that the core `Magento\Checkout\Model\Cart->updateItems` method (i.e. what this before plugin is running against) does exactly the same check. As Magento core is expecting and handling a false `$item`, I think it reasonable for the Yotpo plugin to do so as well.