### PR TITLE
v1.3.9

### DIFF
--- a/Api/Swell/Index/TestManagementInterface.php
+++ b/Api/Swell/Index/TestManagementInterface.php
@@ -7,7 +7,7 @@ interface TestManagementInterface
 
     /**
      * GET for Success api
-     * @return \Magento\Framework\Controller\ResultFactory
+     * @return string
      */
     public function getSuccess();
 }


### PR DESCRIPTION
* Fixed return type declaration on `TestManagementInterface` (string).

*Fix for https://github.com/YotpoLtd/magento2-module-yotpo-loyalty/issues/52