### PR TITLE
v1.4.4: Fixed unexpected `)` in `CouponManagement`

### DIFF
--- a/Model/Api/Swell/Session/CouponManagement.php
+++ b/Model/Api/Swell/Session/CouponManagement.php
@@ -48,7 +48,7 @@ class CouponManagement implements \Yotpo\Loyalty\Api\Swell\Session\CouponManagem
                 $couponCode = $this->_yotpoHelper->prepareCouponCodeValue(
                     (string) $quote->getCouponCode(), // Existing quote coupon(s)
                     (string) $this->_yotpoHelper->getRequest()->getParam('swell_coupon_codes', ''), // Coupon(s) to remove
-                    (string) $this->_yotpoHelper->getRequest()->getParam('coupon_code', ''),  // Coupon(s) to add
+                    (string) $this->_yotpoHelper->getRequest()->getParam('coupon_code', '')  // Coupon(s) to add
                 );
                 $quote->setCouponCode($couponCode)->setTotalsCollectedFlag(false)->collectTotals()->save();
             }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "yotpo/magento2-module-yotpo-loyalty",
     "description": "Magento 2 module for integration with Yotpo",
     "type": "magento2-module",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "repositories": [{
         "type": "git",
         "url": "https://github.com/YotpoLtd/magento2-module-yotpo-loyalty"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Loyalty" setup_version="1.4.3">
+    <module name="Yotpo_Loyalty" setup_version="1.4.4">
         <sequence>
 			<module name="Magento_Catalog" />
         </sequence>


### PR DESCRIPTION
* Fixed unexpected `)` in `CouponManagement`.