### PR TITLE
v1.4.6: Fixed deprecation issue on CLI - Symfony: Command::execute() should always return int...

### DIFF
--- a/Console/Command/RemoveOldSyncRecordsCommand.php
+++ b/Console/Command/RemoveOldSyncRecordsCommand.php
@@ -14,11 +14,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class RemoveOldSyncRecordsCommand extends Command
 {
-
     /**#@+
      * Keys and shortcuts for input arguments and options
      */
-    const FORCE = 'force';
+    public const FORCE = 'force';
     /**#@- */
 
     /**
@@ -83,6 +82,9 @@ class RemoveOldSyncRecordsCommand extends Command
             $output->writeln('<info>' . 'Done :)' . '</info>');
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
         }
+
+        return 0;
     }
 }

--- a/Console/Command/SyncCommand.php
+++ b/Console/Command/SyncCommand.php
@@ -13,12 +13,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class SyncCommand extends Command
 {
-
     /**#@+
      * Keys and shortcuts for input arguments and options
      */
-    const FORCE = 'force';
-    const LIMIT = 'limit';
+    public const FORCE = 'force';
+    public const LIMIT = 'limit';
     /**#@- */
 
     /**
@@ -90,6 +89,9 @@ class SyncCommand extends Command
             $output->writeln('<info>' . 'Done :)' . '</info>');
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
         }
+
+        return 0;
     }
 }

--- a/Console/Command/UninstallCommand.php
+++ b/Console/Command/UninstallCommand.php
@@ -12,10 +12,10 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class UninstallCommand extends Command
 {
-    const CONFIRM_MESSAGE = "<question>Are you sure you want to uninstall Yotpo? (y/n)[n]\n*This will remove all Yotpo attributes & data from DB.\n*This process is irreversible! You should backup first.</question>\n";
-    const RESET_CONFIG_CONFIRM_MESSAGE = "<question>Do you want to also remove all Yotpo configurations (reset to default)? (y/n)[n]</question>\n";
+    public const CONFIRM_MESSAGE = "<question>Are you sure you want to uninstall Yotpo? (y/n)[n]\n*This will remove all Yotpo attributes & data from DB.\n*This process is irreversible! You should backup first.</question>\n";
+    public const RESET_CONFIG_CONFIRM_MESSAGE = "<question>Do you want to also remove all Yotpo configurations (reset to default)? (y/n)[n]</question>\n";
 
-    const SQL_QUERIES = [
+    public const SQL_QUERIES = [
         "default" => [
             "DELETE FROM `setup_module` WHERE `setup_module`.`module` = 'Yotpo_Loyalty'",
         ],
@@ -116,7 +116,10 @@ class UninstallCommand extends Command
             $output->writeln('<info>' . 'Done :(' . '</info>');
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
         }
+
+        return 0;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "yotpo/magento2-module-yotpo-loyalty",
     "description": "Magento 2 module for integration with Yotpo",
     "type": "magento2-module",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "repositories": [{
         "type": "git",
         "url": "https://github.com/YotpoLtd/magento2-module-yotpo-loyalty"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Loyalty" setup_version="1.4.5">
+    <module name="Yotpo_Loyalty" setup_version="1.4.6">
         <sequence>
 			<module name="Magento_Catalog" />
         </sequence>


### PR DESCRIPTION
* Fixed deprecation issue on CLI - Symfony: Command::execute() should always return int - deprecate returning null.