### PR TITLE
v1.4.8: Introduced a new webhook topic: store/information/updated ...

### DIFF
--- a/Console/Command/SendStoreInformationCommand.php
+++ b/Console/Command/SendStoreInformationCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Yotpo\Loyalty\Console\Command;
+
+use Magento\Framework\ObjectManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Yotpo - Send Store Information Webhook
+ */
+class SendStoreInformationCommand extends Command
+{
+    /**#@+
+     * Keys and shortcuts for input arguments and options
+     */
+    public const FORCE = 'force';
+    /**#@- */
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $_objectManager;
+
+    /**
+     * @param \Yotpo\Loyalty\Cron\Jobs
+     */
+    protected $_jobs;
+
+    /**
+     * @var \Yotpo\Loyalty\Helper\Data
+     */
+    protected $_yotpoHelper;
+
+    /**
+     * @method __construct
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager
+    ) {
+        $this->_objectManager = $objectManager;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('yotpo:loyalty:send-store-information')
+            ->setDescription('Send store information webhooks to Yotpo')
+            ->setDefinition([
+                new InputOption(
+                    self::FORCE,
+                    '-f',
+                    InputOption::VALUE_NONE,
+                    'Force submission, ignoring `store_information_webhhoks_enabled`'
+                ),
+            ]);
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->_jobs = $this->_objectManager->get(\Yotpo\Loyalty\Cron\Jobs::class);
+        $this->_yotpoHelper = $this->_objectManager->get(\Yotpo\Loyalty\Helper\Data::class);
+
+        try {
+            $output->writeln('<info>' . 'Working on it (Imagine a spinning gif loager) ...' . '</info>');
+
+            if (!$this->_yotpoHelper->isStoreInformationWebhhoksEnabled() && !$input->getOption(self::FORCE)) {
+                $output->writeln('Store information webhooks have been disabled from the module config. In order to run this command, please re-enable or try again with -f (force).');
+                return 0;
+            }
+            //================================================================//
+            $this->_jobs->initConfig([
+                "output" => $output,
+                "force" => ($input->getOption(self::FORCE)) ? true : false
+            ]);
+
+            $this->_jobs->sendStoreInformationWebhooks();
+            //================================================================//
+
+            $output->writeln('<info>' . 'Done :)' . '</info>');
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/Cron/Jobs.php
+++ b/Cron/Jobs.php
@@ -334,6 +334,47 @@ class Jobs
     }
 
     /**
+     * Send Store Information Webhooks.
+     * @method sendStoreInformationWebhooks
+     * @return $this
+     */
+    public function sendStoreInformationWebhooks()
+    {
+        try {
+            if (!$this->_yotpoHelper->isStoreInformationWebhhoksEnabled() && !$this->_force) {
+                return;
+            }
+            $this->_processOutput("Jobs::sendStoreInformationWebhooks() - [STARTED]", "info");
+            $this->setCrontabAreaCode();
+
+            $enabledAccounts = $this->_yotpoHelper->getEnabledAccounts();
+            $this->_processOutput("Found " . count($enabledAccounts) . " enabled accounts.", 'comment');
+
+            foreach ($enabledAccounts as $guid => $info) {
+                try {
+                    $this->_processOutput("== Sending store information webhook for account: " . $guid . " [Store ID: " . $info['store_id'] . ' | Root API URL: ' . $info['root_api_url'] . "].", 'comment');
+                    $response = $this->_apiRequestHelper->storeInformationWebhookRequest($info['store_id'], \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+                    if ($response->getError()) {
+                        $this->_processOutput('== [ERROR] ' . $response->getMessage(), 'error', [$response]);
+                    } else {
+                        $this->_processOutput('== [SUCCESS] ' . $response->getMessage(), 'comment');
+                    }
+                } catch (\Exception $e) {
+                    $this->_processOutput('== [ERROR] ' . $e->getMessage(), 'error', [$e]);
+                }
+
+                $this->_processOutput('== Moving forward...', 'comment');
+            }
+
+            $this->_processOutput("Jobs::sendStoreInformationWebhooks() - [DONE]", "info");
+        } catch (\Exception $e) {
+            $this->_processOutput('Jobs::sendStoreInformationWebhooks() - [ERROR] ' . $e->getMessage(), 'error', [$e]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Remove Old Sent/Failed Sync Records.
      * @method removeOldSyncRecords
      * @return $this

--- a/Helper/ApiRequest.php
+++ b/Helper/ApiRequest.php
@@ -81,4 +81,17 @@ class ApiRequest extends AbstractApi
 
         return $processedResponse;
     }
+
+    public function storeInformationWebhookRequest($scopeId = null, $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+    {
+        return $this->webhooksRequest(
+            [
+                "api_key" => $this->_yotpoHelper->getSwellApiKey($scope, $scopeId),
+                "topic" => "store/information/updated",
+                "store" => [
+                    "root_api_url" => rtrim($this->_yotpoHelper->getBaseUrl($scope, $scopeId), "/") . "/rest/V1",
+                ],
+            ]
+        );
+    }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -38,6 +38,7 @@ class Data extends AbstractHelper
     public const XML_PATH_CART_PAGE_FULL_ACTION_NAME = "yotpo_loyalty/advanced/cart_page_full_action_name";
     public const XML_PATH_CHECKOUT_PAGE_FULL_ACTION_NAME = "yotpo_loyalty/advanced/checkout_page_full_action_name";
     public const XML_PATH_LOAD_YOTPO_SNIPPET_PATH_PATTERNS = "yotpo_loyalty/advanced/load_yotpo_snippet_path_patterns";
+    public const XML_PATH_STORE_INFORMATION_WEBHOOKS_ENABLED = "yotpo_loyalty/advanced/store_information_webhhoks_enabled";
     //= Others
     public const XML_PATH_CURRENCY_OPTIONS_DEFAULT = "currency/options/default";
     public const XML_PATH_SECURE_BASE_URL = "web/secure/base_url";
@@ -282,6 +283,11 @@ class Data extends AbstractHelper
         return (string) $this->getConfig(self::XML_PATH_LOAD_YOTPO_SNIPPET, $scope, $scopeId, $skipCahce);
     }
 
+    public function isStoreInformationWebhhoksEnabled($scope = null, $scopeId = null, $skipCahce = false)
+    {
+        return $this->getConfig(self::XML_PATH_STORE_INFORMATION_WEBHOOKS_ENABLED, $scope, $scopeId, $skipCahce) ? true : false;
+    }
+
     public function getCartPageFullActionName($scope = null, $scopeId = null, $skipCahce = false)
     {
         return (string) $this->getConfig(self::XML_PATH_CART_PAGE_FULL_ACTION_NAME, $scope, $scopeId, $skipCahce) ?: 'checkout_cart_index';
@@ -470,6 +476,27 @@ class Data extends AbstractHelper
         foreach ($this->getStoreManager()->getStores($withDefault) as $key => $store) {
             if ($this->isEnabled(\Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getId())) {
                 $return[] = $store->getId();
+            }
+        }
+        return $return;
+    }
+
+    public function getEnabledAccounts($withDefault = false)
+    {
+        $return = [];
+        foreach ($this->getStoreManager()->getStores($withDefault) as $key => $store) {
+            if (
+                $this->isEnabled(\Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getId()) &&
+                 ($swellGuid = $this->getSwellGuid(\Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getId())) &&
+                 ($swellApiKey = $this->getSwellApiKey(\Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getId()))
+            ) {
+                $return[$swellGuid] = [
+                    "store_id" => $store->getId(),
+                    "guid" => $swellGuid,
+                    "api_key" => $swellApiKey,
+                    "base_url" => $this->getBaseUrl(\Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getId()),
+                    "root_api_url" => rtrim($this->getBaseUrl(\Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store->getId()), "/") . "/rest/V1",
+                ];
             }
         }
         return $return;

--- a/Observer/Config/BaseUrlChanged.php
+++ b/Observer/Config/BaseUrlChanged.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Yotpo\Loyalty\Observer\Config;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class BaseUrlChanged implements ObserverInterface
+{
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
+     * @var \Yotpo\Loyalty\Helper\ApiRequest
+     */
+    protected $_apiRequestHelper;
+
+    /**
+     * @var \Yotpo\Loyalty\Helper\Data
+     */
+    protected $_yotpoHelper;
+
+    /**
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Yotpo\Loyalty\Helper\ApiRequest $apiRequestHelper
+     * @param \Yotpo\Loyalty\Helper\Data $yotpoHelper
+     */
+    public function __construct(
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Yotpo\Loyalty\Helper\ApiRequest $apiRequestHelper,
+        \Yotpo\Loyalty\Helper\Data $yotpoHelper
+    ) {
+        $this->_storeManager = $storeManager;
+        $this->_apiRequestHelper = $apiRequestHelper;
+        $this->_yotpoHelper = $yotpoHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(Observer $observer)
+    {
+        try {
+            $scopeId = $observer->getEvent()->getStore();
+            $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
+            if (!$scopeId && ($scopeId = $observer->getEvent()->getWebsite())) {
+                $scope = \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE;
+            }
+            if (!$scopeId) {
+                $scope = \Magento\Framework\App\ScopeInterface::SCOPE_DEFAULT;
+            }
+            if (
+                $this->_yotpoHelper->isEnabled($scope, $scopeId) &&
+                $this->_yotpoHelper->isStoreInformationWebhhoksEnabled($scope, $scopeId)
+            ) {
+                $response = $this->_apiRequestHelper->storeInformationWebhookRequest($scopeId, $scope);
+            }
+            if ($response->getError()) {
+                throw new \Exception($response->getMessage());
+            } else {
+                $this->yotpoHelper->log("[Observer\Config\BaseUrlChanged] Successfully sent store information webhhok.", "info");
+            }
+        } catch (\Exception $e) {
+            $this->yotpoHelper->log("[Observer\Config\BaseUrlChanged - ERROR] " . $e->getMessage() . "\n" . $e->getTraceAsString(), "error");
+        }
+
+
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "yotpo/magento2-module-yotpo-loyalty",
     "description": "Magento 2 module for integration with Yotpo",
     "type": "magento2-module",
-    "version": "1.4.7",
+    "version": "1.4.8",
     "repositories": [{
         "type": "git",
         "url": "https://github.com/YotpoLtd/magento2-module-yotpo-loyalty"

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -3,4 +3,7 @@
     <event name="admin_system_config_changed_section_yotpo_loyalty">
         <observer name="yotpo_loyalty_admin_system_config_changed_section_yotpo_loyalty" instance="Yotpo\Loyalty\Observer\Config\Save" />
     </event>
+    <event name="admin_system_config_changed_section_web">
+        <observer name="yotpo_loyalty_admin_system_config_changed_section_web" instance="Yotpo\Loyalty\Observer\Config\BaseUrlChanged" />
+    </event>
 </config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -89,6 +89,11 @@
                         <field id="load_yotpo_snippet">url_path_patterns</field>
                     </depends>
 				</field>
+				<field id="store_information_webhhoks_enabled" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+					<label>Enable Store Information Webhooks</label>
+					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+					<comment>By default, the module will sync your current base URL with Yotpo to ensure it is correctly reflected in your account. You may disable this feature in development or staging environments.</comment>
+				</field>
 				<field id="swell_merchant_info_confirm" translate="label" type="button" sortOrder="1000" showInDefault="1" showInWebsite="1" showInStore="1">
 					<frontend_model>Yotpo\Loyalty\Block\Adminhtml\System\Config\MerchantInfoConfirm</frontend_model>
 				</field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -17,6 +17,7 @@
                 <cart_page_full_action_name>checkout_cart_index</cart_page_full_action_name>
                 <checkout_page_full_action_name>checkout_index_index</checkout_page_full_action_name>
                 <load_yotpo_snippet_path_patterns>#/checkout/?(index/?|\?|$)#</load_yotpo_snippet_path_patterns>
+                <store_information_webhhoks_enabled>1</store_information_webhhoks_enabled>
             </advanced>
         </yotpo_loyalty>
         <csp>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="yotpo_loyalty">
-        <job name="yotpo_sync_queue" instance="Yotpo\Loyalty\Cron\Jobs" method="processSyncQueue">
+        <job name="yotpo_loyalty_sync_queue" instance="Yotpo\Loyalty\Cron\Jobs" method="processSyncQueue">
             <schedule>* * * * *</schedule>
         </job>
-        <job name="yotpo_remove_old_sync_queue" instance="Yotpo\Loyalty\Cron\Jobs" method="removeOldSyncRecords">
+        <job name="yotpo_loyalty_remove_old_sync_queue" instance="Yotpo\Loyalty\Cron\Jobs" method="removeOldSyncRecords">
             <schedule>0 3 * * *</schedule>
+        </job>
+        <job name="yotpo_loyalty_send_store_information" instance="Yotpo\Loyalty\Cron\Jobs" method="sendStoreInformationWebhooks">
+            <schedule>0 */6 * * *</schedule>
         </job>
     </group>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -24,6 +24,7 @@
 		<arguments>
 			<argument name="commands" xsi:type="array">
 				<item name="yotpo_loyalty_remove_old_sync_records" xsi:type="object">Yotpo\Loyalty\Console\Command\RemoveOldSyncRecordsCommand</item>
+				<item name="yotpo_loyalty_send_store_information" xsi:type="object">Yotpo\Loyalty\Console\Command\SendStoreInformationCommand</item>
 				<item name="yotpo_loyalty_sync" xsi:type="object">Yotpo\Loyalty\Console\Command\SyncCommand</item>
 				<item name="yotpo_loyalty_uninstall" xsi:type="object">Yotpo\Loyalty\Console\Command\UninstallCommand</item>
 			</argument>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Loyalty" setup_version="1.4.7">
+    <module name="Yotpo_Loyalty" setup_version="1.4.8">
         <sequence>
 			<module name="Magento_Catalog" />
         </sequence>


### PR DESCRIPTION
* Introduced a new webhook topic (`store/information/updated`) that should run every 6 hours or when the config web section is changed, and send the current root_api_url to Yotpo (unless disabled from config).